### PR TITLE
Support for getting claims from IDToken and call userinfo implicity during authorize flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,18 @@ In this example, we will call it LoginActivity:
 
 #### Authorization.
 
-Have a login button inside LoginActivity. Call the `doAuthorization(Context context)` method 
+Have a login button inside LoginActivity. Call the `doAuthorization()` method 
  when the login button is clicked to call authorization flow.
+ 
+ `authorize(PendingIntent successIntent, PendingIntent failureIntent,
+             Boolean callUserInfo)`
+ 
+ When calling authorize method of LoginService, you have to create completionIntent, and
+  cancelIntent.
+  
+  You can pass either true or false for callUserInfo parameter. If callUserInfo value is true, then userinfo request will be made to the IdentityServer after successful token exchange
+  . Else if callUserInfo value is false, SDK will not make any request to UserInfo Endpoint after
+   token flow. Application can call userinfo endpoint explicitly by calling `getUserInfo(AuthenticationContext, UserInfoRequestHandler.UserInfoResponseCallback)}`
 
 ```java
     findViewById(R.id.login).setOnClickListener(v ->
@@ -106,7 +116,6 @@ Have a login button inside LoginActivity. Call the `doAuthorization(Context cont
 ```java
 private void doAuthorization() {
    
-      mLoginService = new DefaultLoginService(this);
       Intent completionIntent = new Intent(this, UserInfoActivity.class);
       Intent cancelIntent = new Intent(this, LoginActivity.class);
       cancelIntent.putExtra("failed", true);
@@ -114,7 +123,7 @@ private void doAuthorization() {
       PendingIntent successIntent = PendingIntent.getActivity(this, 0, completionIntent, 0);
       PendingIntent failureIntent = PendingIntent.getActivity(this, 0, cancelIntent, 0);
 
-      mLoginService.authorize(successIntent, failureIntent);
+      mLoginService.authorize(successIntent, failureIntent, true);
    }
 ```
    

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'com.squareup.okio:okio:1.14.1'
     implementation 'com.googlecode.json-simple:json-simple:1.1'
     implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.19'
 
 }
 

--- a/library/src/main/java/org/wso2/identity/sdk/android/oidc/constant/Constants.java
+++ b/library/src/main/java/org/wso2/identity/sdk/android/oidc/constant/Constants.java
@@ -48,4 +48,6 @@ public class Constants {
     public static final String ID_TOKEN_HINT = "id_token_hint";
     public static final String POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
 
+    // Constants related to TokenManagementActivity.
+    public static final String AUTHENTICATION_CONTEXT = "context";
 }

--- a/library/src/main/java/org/wso2/identity/sdk/android/oidc/handler/UserInfoRequestHandler.java
+++ b/library/src/main/java/org/wso2/identity/sdk/android/oidc/handler/UserInfoRequestHandler.java
@@ -67,7 +67,7 @@ public class UserInfoRequestHandler extends AsyncTask<Void, Void, UserInfoRespon
             try {
                 if (mAuthenticationContext.getOIDCDiscoveryResponse() == null) {
                     throw new ClientException(
-                            "DiscoveryResponse is null. Reinitiate the " + "authentication");
+                            "DiscoveryResponse is null. Re-initiate the " + "authentication");
                 }
                 String accessToken = mAuthenticationContext.getOAuth2TokenResponse()
                         .getAccessToken();

--- a/library/src/main/java/org/wso2/identity/sdk/android/oidc/model/OAuth2TokenResponse.java
+++ b/library/src/main/java/org/wso2/identity/sdk/android/oidc/model/OAuth2TokenResponse.java
@@ -18,7 +18,14 @@
 
 package org.wso2.identity.sdk.android.oidc.model;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
 import java.io.Serializable;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class contains the TokenResponse.
@@ -32,6 +39,7 @@ public class OAuth2TokenResponse implements Serializable {
     private Long mAccessTokenExpirationTime;
     private String mIdToken;
     private String mRefreshToken;
+    private IDTokenResponse mIdTokenResponse;
 
     /**
      * Set idToken.
@@ -39,13 +47,15 @@ public class OAuth2TokenResponse implements Serializable {
      * @param idToken idToken.
      */
     public void setIdToken(String idToken) {
+
         this.mIdToken = idToken;
+        this.mIdTokenResponse = new IDTokenResponse();
     }
 
     /**
      * Set accessToken.
      *
-     * @param accessToken accesstoken.
+     * @param accessToken accessToken.
      */
     public void setAccessToken(String accessToken) {
         this.mAccessToken = accessToken;
@@ -121,5 +131,106 @@ public class OAuth2TokenResponse implements Serializable {
      */
     public String getRefreshToken() {
         return mRefreshToken;
+    }
+
+    /**
+     * Returns IDToken Response.
+     *
+     * @return IDTokenResponse object.
+     */
+    public IDTokenResponse getIdTokenResponse() {
+
+        return mIdTokenResponse;
+    }
+
+    /**
+     * Stores IDToken response.
+     */
+    public class IDTokenResponse implements Serializable {
+
+        private static final long serialVersionUID = -3623225641770681283L;
+
+        /**
+         * Returns subject(sub) claim of IdToken.
+         *
+         * @return subject.
+         * @throws ParseException
+         */
+        public String getSubject() throws ParseException {
+
+            return getJWTClaimsSet().getSubject();
+        }
+
+        /**
+         * Returns Issuer(iss) claim of IdToken.
+         *
+         * @return Issuer.
+         * @throws ParseException
+         */
+        public String getIssuer() throws ParseException {
+
+            return getJWTClaimsSet().getIssuer();
+        }
+
+        /**
+         * Returns Audience(aud) claim of IdTOken.
+         *
+         * @return Audience.
+         * @throws ParseException
+         */
+        public List<String> getAudience() throws ParseException {
+
+            return getJWTClaimsSet().getAudience();
+        }
+
+        /**
+         * Returns IssueTime(iat) claim of IdToken.
+         *
+         * @return IssueTime.
+         * @throws ParseException
+         */
+        public Date getIssueTime() throws ParseException {
+
+            return getJWTClaimsSet().getIssueTime();
+        }
+
+        /**
+         * Returns ExpiryTime(exp) of IDToken
+         *
+         * @return ExpiryTime.
+         * @throws ParseException
+         */
+        public Date getExpiryTime() throws ParseException {
+
+            return getJWTClaimsSet().getExpirationTime();
+        }
+
+        /**
+         * Returns Map of all claims.
+         *
+         * @return Map of all claims.
+         * @throws ParseException
+         */
+        public Map<String, Object> getClaims() throws ParseException {
+
+            return getJWTClaimsSet().getClaims();
+        }
+
+        /**
+         * Returns the claim value of the required claim.
+         *
+         * @param claim ClaimName.
+         * @return ClaimValue.
+         * @throws ParseException
+         */
+        public String getClaim(String claim) throws ParseException {
+
+            return (String) getJWTClaimsSet().getStringClaim(claim);
+        }
+
+        private JWTClaimsSet getJWTClaimsSet() throws ParseException {
+
+            return SignedJWT.parse(mIdToken).getJWTClaimsSet();
+        }
     }
 }

--- a/library/src/main/java/org/wso2/identity/sdk/android/oidc/sso/DefaultLoginService.java
+++ b/library/src/main/java/org/wso2/identity/sdk/android/oidc/sso/DefaultLoginService.java
@@ -74,12 +74,21 @@ public class DefaultLoginService implements LoginService {
     }
 
     /**
-     * Handles the authorization flow by getting the endpoints from discovery service.
+     * Handles authorization flow by getting the endpoints from discovery service. If callUserInfo
+     * value is true, then UserInfo request will happen. Else if callUserInfo value
+     * is false, SDK will not make any request to UserInfo Endpoint after token flow. Application can call
+     * userinfo endpoint explicitly by calling
+     * {@link #getUserInfo(AuthenticationContext, UserInfoRequestHandler.UserInfoResponseCallback)}.
+     * After successful authorization, AuthenticationContext object will be returned in the success
+     * intent.
      *
-     * @param successIntent successIntent.
-     * @param failureIntent failureIntent.
+     * @param successIntent Success intent.
+     * @param failureIntent Failure Intent.
+     * @param callUserInfo  If it is true, Request to UserInfo endpoint will happen after token
+     *                      exchange. Else no request to user info endpoint.
      */
-    public void authorize(PendingIntent successIntent, PendingIntent failureIntent) {
+    public void authorize(PendingIntent successIntent, PendingIntent failureIntent,
+            Boolean callUserInfo) {
 
         // Creating a authentication context object to store context.
         AuthenticationContext authenticationContext = new AuthenticationContext();
@@ -89,12 +98,13 @@ public class DefaultLoginService implements LoginService {
                     if (exception != null) {
                         Log.e(LOG_TAG, "Error while calling discovery endpoint", exception);
                     } else {
+                        Log.i(LOG_TAG, "CallUserInfo" + callUserInfo);
                         authenticationContext.setOIDCDiscoveryResponse(oidcDiscoveryResponse);
                         Log.i(LOG_TAG, oidcDiscoveryResponse.getAuthorizationEndpoint().toString());
                         authorizeRequest(TokenManagementActivity
                                         .createStartIntent(mContext.get(), successIntent, failureIntent,
-                                                mOAuth2TokenResponse, authenticationContext), failureIntent,
-                                authenticationContext);
+                                                mOAuth2TokenResponse, authenticationContext, callUserInfo),
+                                failureIntent, authenticationContext);
                     }
 
                 }).execute();

--- a/library/src/main/java/org/wso2/identity/sdk/android/oidc/sso/LoginService.java
+++ b/library/src/main/java/org/wso2/identity/sdk/android/oidc/sso/LoginService.java
@@ -29,15 +29,21 @@ import org.wso2.identity.sdk.android.oidc.handler.UserInfoRequestHandler;
 public interface LoginService {
 
     /**
-     * Handles authorization flow.
+     * Handles authorization flow and if callUserInfo value is true, then userinfo request will
+     * be made to the IdentityServer after successful token exchange. Else if callUserInfo value
+     * is false, SDK will not make any request to UserInfo Endpoint after token flow. Application can call
+     * userinfo endpoint explicitly by calling
+     * {@link #getUserInfo(AuthenticationContext, UserInfoRequestHandler.UserInfoResponseCallback)}
      *
      * @param successIntent Success intent.
      * @param failureIntent Failure Intent.
+     * @param callUserInfo  If it is true, Request to UserInfo endpoint will happen after token
+     *                      exchange. Else no request to user info endpoint.
      */
-    void authorize(PendingIntent successIntent, PendingIntent failureIntent);
+    void authorize(PendingIntent successIntent, PendingIntent failureIntent, Boolean callUserInfo);
 
     /**
-     * Handles the call to userinfo endpoint.
+     * Handles the call to UserInfo endpoint.
      *
      * @param context  Authentication context.
      * @param callback Callback.


### PR DESCRIPTION
## Purpose
This includes the following two improvements.

1. Included a IDTokenResponse after token exchange and provides the capability to get claims from IDToken.
2. If application wants, it can implicitly call userinfo endpoint during authorize flow passing `callUserInfo` parameter. 

If callUserInfo
- value is true, then UserInfo request will happen. 
- Else if callUserInfo value is false, SDK will not make any request to UserInfo Endpoint after token flow. Application can call userinfo endpoint explicitly by calling
   ` getUserInfo(AuthenticationContext, UserInfoRequestHandler.UserInfoResponseCallback)}.`
